### PR TITLE
ci: route composer-audit through magento-ci-workflows reusable

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       skip-composer-audit: true
 
   magento-composer-audit:
-    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.0
+    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.1
     secrets:
       MAGENTO_REPO_USERNAME: ${{ secrets.MAGENTO_REPO_USERNAME }}
       MAGENTO_REPO_PASSWORD: ${{ secrets.MAGENTO_REPO_PASSWORD }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,3 +21,11 @@ jobs:
 
   composer-audit:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    with:
+      skip-composer-audit: true
+
+  magento-composer-audit:
+    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.0
+    secrets:
+      MAGENTO_REPO_USERNAME: ${{ secrets.MAGENTO_REPO_USERNAME }}
+      MAGENTO_REPO_PASSWORD: ${{ secrets.MAGENTO_REPO_PASSWORD }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       skip-composer-audit: true
 
   magento-composer-audit:
-    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.2
+    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.3
     secrets:
       MAGENTO_REPO_USERNAME: ${{ secrets.MAGENTO_REPO_USERNAME }}
       MAGENTO_REPO_PASSWORD: ${{ secrets.MAGENTO_REPO_PASSWORD }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       skip-composer-audit: true
 
   magento-composer-audit:
-    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.1
+    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.2
     secrets:
       MAGENTO_REPO_USERNAME: ${{ secrets.MAGENTO_REPO_USERNAME }}
       MAGENTO_REPO_PASSWORD: ${{ secrets.MAGENTO_REPO_PASSWORD }}


### PR DESCRIPTION
## Problem

`composer-audit / Composer Audit` from the `netresearch/typo3-ci-workflows` reusable security.yml fails on every master push because it runs `composer install` without authentication to `repo.magento.com`, breaking on `magento/framework`, `magento/module-backend` and `magento/module-config`. Those packages live on the Magento Marketplace repo which requires `MAGENTO_REPO_USERNAME` / `MAGENTO_REPO_PASSWORD`. The TYPO3-oriented reusable workflow has no way to pass Marketplace credentials through.

## Solution

This repo now calls a Magento-aware reusable workflow that accepts Marketplace credentials as workflow secrets.

- `composer-audit` (typo3 reusable): keep for `gitleaks` / `preflight` / `opengrep` SAST. Set `skip-composer-audit: true` so its broken composer-audit step is skipped.
- `magento-composer-audit` (new): calls [`netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.0`](https://github.com/netresearch/magento-ci-workflows/blob/main/.github/workflows/composer-audit.yml) with `MAGENTO_REPO_USERNAME` / `MAGENTO_REPO_PASSWORD` passed in as workflow secrets. Runs `composer install --no-dev` against `repo.magento.com` with proper auth, then `composer audit`.

## Secret provisioning

`MAGENTO_REPO_USERNAME` and `MAGENTO_REPO_PASSWORD` are mirrored from HashiCorp Vault (`ci/<gitlab-project-path>` per CI-390 — single source of truth) into this repo's Actions secrets. To rotate: update the Vault entry, then re-run the sync script.

## Coverage

| Coverage | Before | After |
|---|---|---|
| gitleaks (secret scanning) | ✓ | ✓ |
| preflight (event gate) | ✓ | ✓ |
| dependency-review (PR-diff CVE) | ✓ | ✓ |
| opengrep (SAST) | ✓ | ✓ |
| composer-audit (CVE detection on installed deps) | ✗ broken | ✓ working with Marketplace auth |

## Test plan

- [ ] PR-CI: `magento-composer-audit` job runs `composer install` and reaches `composer audit` step (validates Marketplace auth + composer resolve)
- [ ] After merge: master-push security workflow run is green (vs. today's failure)