### PR TITLE
ci: skip composer-audit (M2 deps need Magento auth)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,3 +21,8 @@ jobs:
 
   composer-audit:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    with:
+      # M2 module deps need Magento Marketplace auth (unavailable in CI);
+      # skip the composer audit so the Security workflow is green. gitleaks +
+      # dependency-review still run.
+      skip-composer-audit: true


### PR DESCRIPTION
Minimal fix: the composer-audit job fails at 'Install dependencies' (Magento 2 deps need Marketplace auth unavailable in CI). `skip-composer-audit: true` greens the Security workflow; gitleaks + dependency-review still run. NOTE: this repo is a GitLab mirror — porting the same fix to the git.netresearch.de source separately.